### PR TITLE
Change/selinux detection

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Rsync server
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.5
   platforms:
   - name: EL
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,3 @@ galaxy_info:
 
 dependencies:
 - role: ome.logrotate
-- role: ome.selinux_utils

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     name: rsync_export_all_ro
     state: yes
     persistent: yes
-  when: selinux_enabled
+  when: ansible_facts.selinux is defined and ansible_facts.selinux.status == 'enabled'
 
 - name: rsyncd | start and enable service
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     name: rsync_export_all_ro
     state: yes
     persistent: yes
-  when: ansible_facts.selinux is defined and ansible_facts.selinux.status == 'enabled'
+  when: ansible_facts.selinux.status == 'enabled'
 
 - name: rsyncd | start and enable service
   become: yes

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,2 +1,1 @@
 - src: ome.logrotate
-- src: ome.selinux_utils


### PR DESCRIPTION
SELinux can be tested by Ansible itself instead of relying on an external role dependency. 
This behaviour should be consistent around Ansible 2.4.1. 

I'm calling the fact it in the namespaced way, which got introduced in Ansible 2.5, so I upped the minimal version required to 2.5. 