### PR TITLE
Ansible 2.8 fixes

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -34,5 +34,14 @@ jobs:
         with:
           scenario: ${{ matrix.scenario }}
 
-# notifications:
-#   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  publish:
+    name: Galaxy
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: galaxy
+        uses: ome/action-ansible-galaxy-publish@main
+        with:
+          galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rsync Server
 ============
 
-[![Build Status](https://travis-ci.org/ome/ansible-role-rsync-server.svg)](https://travis-ci.org/ome/ansible-role-rsync-server)
+[![Actions Status](https://github.com/ome/ansible-role-rsync-server/workflows/Molecule/badge.svg)](https://github.com/ome/ansible-role-rsync-server/actions)
 [![Ansible Role](https://img.shields.io/ansible/role/41886.svg)](https://galaxy.ansible.com/ome/rsync_server/)
 
 Setup rsync as a server.

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -14,4 +14,4 @@ def test_rsync_running(host):
 
 def test_connect_rsync(host):
     out = host.check_output('rsync rsync://localhost')
-    assert re.match('dataset-1\s+Public datasets', out)
+    assert re.match(r'dataset-1\s+Public datasets', out)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,14 @@
   file:
     path: /var/log/rsyncd
     state: directory
+    mode: 0755
 
 - name: rsyncd | configure shares
   become: true
   template:
     dest: /etc/rsyncd.conf
     src: etc-rsyncd-conf.j2
+    mode: 0644
     # No need to reload, file is re-read on each client connection.
 
 - name: rsyncd | configure logrotate
@@ -26,6 +28,7 @@
     backup: false
     dest: /etc/logrotate.d/rsyncd
     src: logrotated-rsyncd.j2
+    mode: 0644
 
 - name: rsyncd | selinux allow network connect
   become: true


### PR DESCRIPTION
Fixes Ansible 2.8 lint errors - see https://github.com/ome/ansible-roles/issues/66
Updates the GitHub workflow publication step

Proposed tag: 1.0.2